### PR TITLE
Fix bug in blender2.9.3. Currently tested in blender 2.8.3 and 2.9.3

### DIFF
--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -22,6 +22,12 @@ jobs:
           pip install
           build
           --user
+      - name: Install numpy
+        run: >-
+          python -m
+          pip install
+          numpy
+          --user
       - name: Build a binary wheel and a source tarball
         run: >-
           python -m
@@ -29,11 +35,11 @@ jobs:
           --sdist
           --wheel
           --outdir dist/
-      # - name: Publish distribution 📦 to Test PyPI
-      #   uses: pypa/gh-action-pypi-publish@master
-      #   with:
-      #     password: ${{ secrets.TEST_PYPI_KEY }}
-      #     repository_url: https://test.pypi.org/legacy/
+      - name: Publish distribution 📦 to Test PyPI
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          password: ${{ secrets.TEST_PYPI_KEY }}
+          repository_url: https://test.pypi.org/legacy/
       - name: Publish distribution 📦 to PyPI
         if: startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@master

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ services:
 
 before_install:
   - docker pull nytimes/blender:latest
+  - docker pull nytimes/blender:2.91-cpu-ubuntu18.04
   - docker pull nytimes/blender:2.83-cpu-ubuntu18.04
   - zip -r .github/travis/blendernc.zip ../blendernc
   - pip install -r requirements.txt

--- a/blendernc/UI_operators.py
+++ b/blendernc/UI_operators.py
@@ -70,9 +70,6 @@ class Import_OT_mfnetCDF(bpy.types.Operator, ImportHelper):
     bl_label = "Load netCDF"
     bl_description = "Import netCDF with xarray"
 
-    # ImportHelper mixin class uses this
-    filename_ext: ".nc"
-
     filter_glob: bpy.props.StringProperty(
         default="*.nc",
         options={"HIDDEN"},

--- a/blendernc/blendernc.py
+++ b/blendernc/blendernc.py
@@ -24,7 +24,9 @@ from .nodes.selecting.BlenderNC_NT_drop_dims import BlenderNC_NT_drop_dims
 from .nodes.selecting.BlenderNC_NT_select_axis import BlenderNC_NT_select_axis
 from .nodes.selecting.BlenderNC_NT_select_time import BlenderNC_NT_select_time
 from .nodes.shortcuts.BlenderNC_NT_basic_nodes import BlenderNC_NT_basic_nodes
-from .nodes.vectors.BlenderNC_NT_line_int_conv import BlenderNC_NT_lic
+
+# TODO: Uncomment after fixing issue with Python header.
+# from .nodes.vectors.BlenderNC_NT_line_int_conv import BlenderNC_NT_lic
 from .operators import (
     BlenderNC_OT_apply_material,
     BlenderNC_OT_colorbar,
@@ -69,7 +71,8 @@ classes = [
     BlenderNC_NT_preloader,
     BlenderNC_NT_output,
     # Vectors
-    BlenderNC_NT_lic,
+    # TODO: Uncomment after fixing issue with Python header.
+    # BlenderNC_NT_lic,
     # Nodes shortcuts
     BlenderNC_NT_basic_nodes,
     # Shader Nodes

--- a/blendernc/core/logging.py
+++ b/blendernc/core/logging.py
@@ -14,10 +14,10 @@ class Timer:
 
     def tick(self, label=""):
         if label == "":
-            self.nolabel.append(time.clock())
+            self.nolabel.append(time.time())
             self.timestamps[label] = self.nolabel
         else:
-            self.tmp.append(time.clock())
+            self.tmp.append(time.time())
             self.timestamps[label] = self.tmp
             if len(self.timestamps[label]) == 2:
 

--- a/blendernc/decorators.py
+++ b/blendernc/decorators.py
@@ -3,7 +3,7 @@ import functools
 
 import bpy
 
-from .msg_errors import unselected_nc_file, unselected_nc_var
+from .msg_errors import unselected_nc_var, unselected_variable
 
 
 class NodesDecorators(object):
@@ -88,7 +88,7 @@ class NodesDecorators(object):
                     connections["output"].append(
                         [link.from_node.bl_idname for link in output_links]
                     )
-        print(connections)
+        # print(connections)
         return connections
 
     @classmethod
@@ -172,7 +172,7 @@ class NodesDecorators(object):
         else:
             # Exception for netCDFNode to update dataset
             bpy.context.window_manager.popup_menu(
-                unselected_nc_file, title="Error", icon="ERROR"
+                unselected_variable, title="Error", icon="ERROR"
             )
             cls.unlink_input(node)
             return False
@@ -180,6 +180,7 @@ class NodesDecorators(object):
     @classmethod
     def select_var_dataset(cls, node):
         if node.blendernc_file != node.inputs[0].links[0].from_socket.text:
+            node.blendernc_file = node.inputs[0].links[0].from_socket.text
             bpy.ops.blendernc.ncload(
                 file_path=node.blendernc_file,
                 node_group=node.rna_type.id_data.name,
@@ -187,8 +188,7 @@ class NodesDecorators(object):
             )
             return False
         elif (
-            node.blendernc_netcdf_vars != "No dataset"
-            and node.blendernc_netcdf_vars != ""
+            node.blendernc_netcdf_vars != "No var" and node.blendernc_netcdf_vars != ""
         ):
             return True
         else:
@@ -231,7 +231,6 @@ class NodesDecorators(object):
     @staticmethod
     def get_blendernc_file(node):
         # TODO disconnect if not connected to proper node.
-        node.blendernc_file = node.inputs[0].links[0].from_socket.text
         if not node.blendernc_file:
             node.blendernc_file = node.inputs[0].links[0].from_node.blendernc_file
 

--- a/blendernc/msg_errors.py
+++ b/blendernc/msg_errors.py
@@ -5,6 +5,10 @@ def unselected_nc_file(self, context):
     self.layout.label(text="Select a netCDF file.")
 
 
+def unselected_variable(self, context):
+    self.layout.label(text="Select a variable file.")
+
+
 def unselected_nc_var(self, context):
     self.layout.label(text="Select a variable from the netCDF file.")
 

--- a/blendernc/operators.py
+++ b/blendernc/operators.py
@@ -292,7 +292,7 @@ class BlenderNC_OT_apply_material(bpy.types.Operator):
         blendernc_material.node_tree.links.new(cmap.inputs[0], imagetex.outputs[0])
         blendernc_material.node_tree.links.new(bump.inputs[2], imagetex.outputs[0])
         blendernc_material.node_tree.links.new(P_BSDF.inputs[0], cmap.outputs[0])
-        blendernc_material.node_tree.links.new(P_BSDF.inputs[19], bump.outputs[0])
+        blendernc_material.node_tree.links.new(P_BSDF.inputs[-3], bump.outputs[0])
 
         imagetex.image = bpy.data.images.get("BlenderNC_default")
 

--- a/blendernc/operators.py
+++ b/blendernc/operators.py
@@ -53,7 +53,7 @@ class BlenderNC_OT_ncload(bpy.types.Operator):
         if self.node_group == "BlenderNC":
             var_names = get_var(node.blendernc_dict[unique_identifier]["Dataset"])
             bpy.types.Scene.blendernc_netcdf_vars = bpy.props.EnumProperty(
-                items=var_names, name="", update=update_nodes
+                items=var_names, name="Select Variable", update=update_nodes
             )
         # Create new node in BlenderNC node
         blendernc_nodes = [

--- a/blendernc/panels.py
+++ b/blendernc/panels.py
@@ -105,7 +105,10 @@ class BlenderNC_UI_PT_3dview(bpy.types.Panel):
             box_asts.label(text="Select variable:", icon="WORLD_DATA")
             box_asts.prop(scn, "blendernc_netcdf_vars", text="")
             box_asts.prop(scn, "blendernc_animate")
-            box_asts.prop(scn, "blendernc_resolution")
+            row = box_asts.row(align=True)
+            split = row.split(factor=0.9)
+            split.prop(scn, "blendernc_resolution")
+            split.label(text=str("%"))
             # TO DO: Add info?
             # box_asts.label(text="INFO", icon='INFO')
 

--- a/blendernc/panels.py
+++ b/blendernc/panels.py
@@ -50,7 +50,7 @@ bpy.types.Scene.blendernc_resolution = bpy.props.FloatProperty(
 )
 
 bpy.types.Scene.blendernc_netcdf_vars = bpy.props.EnumProperty(
-    items=empty_item(), name="Select variable"
+    items=empty_item(), name="No variable"
 )
 
 bpy.types.Scene.blendernc_file = bpy.props.StringProperty(

--- a/blendernc/python_functions.py
+++ b/blendernc/python_functions.py
@@ -55,11 +55,15 @@ def get_var(ncdata):
             (variables[ii], variables[ii], variables[ii], "DISK_DRIVE", ii + 1)
             for ii in range(len(variables))
         ]
-    return var_names
+    return select_item() + [None] + var_names
 
 
 def empty_item():
-    return [("No dataset", "No dataset ", "Empty", "CANCEL", 0)]
+    return [("No var", "No variable", "Empty", "CANCEL", 0)]
+
+
+def select_item():
+    return [("No var", "Select variable", "Empty", "NODE_SEL", 0)]
 
 
 def get_possible_variables(node, context):

--- a/blendernc/python_functions.py
+++ b/blendernc/python_functions.py
@@ -256,16 +256,17 @@ def dict_update(node, context):
         if "selected_var" in dataset_dict.keys()
         else ""
     )
+    node_tree = node.rna_type.id_data.name
+    unique_identifier = node.blendernc_dataset_identifier
     # Update if user selected a new variable.
     if selected_var and selected_var != node.blendernc_netcdf_vars:
         # Update dict
         update_dict(node.blendernc_netcdf_vars, node)
-        node_tree = node.rna_type.id_data.name
-        unique_identifier = node.blendernc_dataset_identifier
         del_cache(node_tree, unique_identifier)
         update_value_and_node_tree(node, context)
     else:
         update_dict(node.blendernc_netcdf_vars, node)
+        del_cache(node_tree, unique_identifier)
         update_value(node, context)
 
 
@@ -577,11 +578,10 @@ def ui_material():
 
 
 def update_colormap_interface(context, node, node_tree):
-    node = bpy.data.node_groups[node_tree].nodes[node]
-    unique_data_dict = get_unique_data_dict(node)
     # Get var range
-    max_val = unique_data_dict["selected_var"]["max_value"]
-    min_val = unique_data_dict["selected_var"]["min_value"]
+    max_val, min_val = get_max_min_data(context, node, node_tree)
+
+    node = bpy.data.node_groups[node_tree].nodes[node]
 
     # Find all nodes using the selected image in the node.
     all_nodes = get_all_nodes_using_image(node.image.name)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import numpy as np
 
 # TODO: Fix issue with blender not having python headers.
 # from Cython.Build import cythonize
-from Cython.Distutils import build_ext
+# from Cython.Distutils import build_ext
 from setuptools import setup
 
 extensions = Extension(
@@ -25,7 +25,7 @@ setup(
     install_requires=[],
     zip_safe=True,
     include_dirs=[np.get_include()],
-    cmdclass={"build_ext": build_ext},
+    # cmdclass={"build_ext": build_ext},
     # TODO: Fix issue with blender not having python headers.
     # ext_modules=cythonize([extensions], build_dir="cython_build"),
 )

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ extensions = Extension(
 
 setup(
     name="blendernc",
-    version="0.1.0",
+    version="0.1.1",
     description="Blender add-on to import netCDF",
     url="https://github.com/blendernc/blendernc",
     author="josuemtzmo",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,9 @@
 from distutils.extension import Extension
 
 import numpy as np
-from Cython.Build import cythonize
+
+# TODO: Fix issue with blender not having python headers.
+# from Cython.Build import cythonize
 from Cython.Distutils import build_ext
 from setuptools import setup
 
@@ -24,5 +26,6 @@ setup(
     zip_safe=True,
     include_dirs=[np.get_include()],
     cmdclass={"build_ext": build_ext},
-    ext_modules=cythonize([extensions], build_dir="cython_build"),
+    # TODO: Fix issue with blender not having python headers.
+    # ext_modules=cythonize([extensions], build_dir="cython_build"),
 )


### PR DESCRIPTION
This fixes the issue raised by @StephanSiemen, the main issue is that the operator expected an expresion not a string. 

```
SyntaxError: Forward reference must be an expression -- got '.nc'
```

This expression was unused, thus it was deleted.