### PR TITLE
Performance boost

### DIFF
--- a/blendernc/UI_operators.py
+++ b/blendernc/UI_operators.py
@@ -40,13 +40,12 @@ class BlenderNC_OT_Simple_UI(bpy.types.Operator):
         else:
             resol = node_group.nodes.get(translate("Resolution"))
             output = node_group.nodes.get(translate("Output"))
-        # LINK
-        node_group.links.new(resol.inputs[0], datacube.outputs[0])
 
         resol.blendernc_resolution = scene.blendernc_resolution
 
         # LINK
-        node_group.links.new(output.inputs[0], resol.outputs[0])
+        node_group.links.new(resol.inputs[0], datacube.outputs[0])
+
         bpy.ops.image.new(
             name=default_node_group_name + "_default",
             width=1024,
@@ -58,7 +57,9 @@ class BlenderNC_OT_Simple_UI(bpy.types.Operator):
         )
         output.image = bpy.data.images.get(default_node_group_name + "_default")
         output.update_on_frame_change = scene.blendernc_animate
-        output.update()
+
+        # LINK
+        node_group.links.new(output.inputs[0], resol.outputs[0])
         return {"FINISHED"}
 
 

--- a/blendernc/core/update_ui.py
+++ b/blendernc/core/update_ui.py
@@ -299,9 +299,9 @@ def update_res(scene, context):
     """
     Simple UI function to update BlenderNC node tree.
     """
-    bpy.data.node_groups.get("BlenderNC").nodes.get(
-        translate("Resolution")
-    ).blendernc_resolution = scene.blendernc_resolution
+    res_node = bpy.data.node_groups.get("BlenderNC").nodes.get(translate("Resolution"))
+    if res_node:
+        res_node.blendernc_resolution = scene.blendernc_resolution
 
 
 def update_proxy_file(self, context):

--- a/blendernc/core/update_ui.py
+++ b/blendernc/core/update_ui.py
@@ -139,10 +139,6 @@ def update_range(node, context):
         min_val = node.blendernc_dataset_min
     except AttributeError:
         max_val, min_val = update_random_range(unique_data_dict)
-        if max_val == min_val:
-            PrintMessage(same_min_max_value, title="Error", icon="ERROR")
-            # Cancel update range and force the user to change the resolution.
-            return
 
     unique_data_dict["selected_var"]["max_value"] = max_val
     unique_data_dict["selected_var"]["min_value"] = min_val
@@ -151,18 +147,29 @@ def update_range(node, context):
         NodeTree = node.rna_type.id_data.name
         frame = bpy.context.scene.frame_current
         bnc_pyfunc.refresh_cache(NodeTree, unique_identifier, frame)
+        update_value_and_node_tree(node, context)
 
-    update_value_and_node_tree(node, context)
 
-
-def update_random_range(unique_data_dict):
+def update_random_range(unique_data_dict, n=20):
+    counter = 0
+    max_val = 0
+    min_val = 0
     dataset = unique_data_dict["Dataset"]
     sel_var = unique_data_dict["selected_var"]
     selected_variable = sel_var["selected_var_name"]
     selected_var_dataset = dataset[selected_variable]
-    rand_sample = bnc_pyfunc.dataarray_random_sampling(selected_var_dataset, 100)
-    max_val = np.nanmax(rand_sample)
-    min_val = np.nanmin(rand_sample)
+    if max_val == min_val:
+        while counter < 4 and max_val == min_val:
+            rand_sample = bnc_pyfunc.dataarray_random_sampling(selected_var_dataset, n)
+            max_val = np.nanmax(rand_sample)
+            min_val = np.nanmin(rand_sample)
+            n += 20
+            counter += 1
+        if counter == 4 and max_val == min_val:
+            PrintMessage(same_min_max_value, title="Error", icon="ERROR")
+            # Cancel update range and force the user to change
+            # the resolution or define max and min.
+            return
     return max_val, min_val
 
 

--- a/blendernc/core/update_ui.py
+++ b/blendernc/core/update_ui.py
@@ -5,7 +5,7 @@ import blendernc.get_utils as bnc_gutils
 import blendernc.nodes.cmaps.utils_colorramp as bnc_cramputils
 import blendernc.python_functions as bnc_pyfunc
 from blendernc.core.logging import Timer
-from blendernc.messages import PrintMessage, drop_dim, huge_image, increase_resolution
+from blendernc.messages import PrintMessage, drop_dim, huge_image, same_min_max_value
 from blendernc.translations import translate
 
 
@@ -53,12 +53,15 @@ class UpdateImage:
 
         if self.frame is False:
             return self.frame
+        self.timer.tick("Load Frame")
+
+        self.timer.tick("Store in Cache")
+        self.store_image_in_cache(self.frame, img_x, img_y)
+        self.timer.tick("Store in Cache")
 
         self.timer.tick("Update time")
         update_datetime_text(self.node, self.node_tree, self.frame)
         self.timer.tick("Update time")
-        self.store_image_in_cache(self.frame, img_x, img_y)
-        self.timer.tick("Load Frame")
 
         # In case data has been pre-loaded
         datacube_cache = self.scene.datacube_cache[self.node_tree]
@@ -134,7 +137,7 @@ def update_range(node, context):
     except AttributeError:
         max_val, min_val = update_random_range(unique_data_dict)
         if max_val == min_val:
-            PrintMessage(increase_resolution, title="Error", icon="ERROR")
+            PrintMessage(same_min_max_value, title="Error", icon="ERROR")
             # Cancel update range and force the user to change the resolution.
             return
 

--- a/blendernc/image.py
+++ b/blendernc/image.py
@@ -77,9 +77,8 @@ def from_data_to_pixel_value(data, image_float=True):
     # BW in RGB format for image
     rgb = np.repeat(data[:, :, np.newaxis], 3, axis=2)
     rgba = np.concatenate((rgb, alpha_channel[:, :, np.newaxis]), axis=2)
-    rgba = rgba.ravel()
     # Using foreach_set function for performance ( requires a 32-bit argument)
     if image_float:
-        return np.float32(rgba)
+        return np.float32(rgba.ravel())
     else:
-        return np.float16(rgba)
+        return np.float16(rgba.ravel())

--- a/blendernc/messages.py
+++ b/blendernc/messages.py
@@ -80,8 +80,9 @@ def client_exists():
     return text
 
 
-def increase_resolution():
-    text = "Increase resolution."
+def same_min_max_value():
+    text = "Increase resolution or define the max and min values of the dataset"
+    text += "by using a Range node."
     return text
 
 

--- a/blendernc/messages.py
+++ b/blendernc/messages.py
@@ -38,10 +38,8 @@ def load_after_restart():
 
 
 def active_selection_preference():
-    text = (
-        "The active selection has preference over picked object. "
-        + "Make sure you selected the right mesh to apply material."
-    )
+    text = "The active selection has preference over picked object. "
+    text += "Make sure you selected the right mesh to apply material."
     return text
 
 
@@ -81,7 +79,9 @@ def client_exists():
 
 
 def same_min_max_value():
-    text = "Increase resolution or define the max and min values of the dataset"
+    text = "Random sampling has been attempted 4 times. "
+    text += "Please increase the resolution "
+    text += "or define the max and min values of the dataset "
     text += "by using a Range node."
     return text
 

--- a/blendernc/python_functions.py
+++ b/blendernc/python_functions.py
@@ -54,10 +54,9 @@ def dataarray_random_sampling(dataarray, n):
     randint = np.random.randint
     len_data_dims = len(dataarray_dims)
     dims_dict = {
-        dataarray_dims[ii]: np.array(
-            [randint(0, len(dataarray[dataarray_dims[ii]])) for nn in range(n)],
-            dtype=int,
-        )
+        dataarray_dims[ii]: [
+            randint(0, len(dataarray[dataarray_dims[ii]])) for nn in range(n)
+        ]
         for ii in range(len_data_dims)
     }
     values = dataarray.isel(dims_dict).values

--- a/blendernc/python_functions.py
+++ b/blendernc/python_functions.py
@@ -50,19 +50,19 @@ def select_datacube():
 
 
 def dataarray_random_sampling(dataarray, n):
-    values = np.zeros(n) * np.nan
     dataarray_dims = [dim for dim in dataarray.dims]
-    counter = 0
     randint = np.random.randint
-    while not np.isfinite(values).all():
-        len_data_dims = len(dataarray_dims)
-        dims_dict = {
-            dataarray_dims[ii]: randint(0, len(dataarray[dataarray_dims[ii]]))
-            for ii in range(len_data_dims)
-        }
-        values[counter] = dataarray.isel(dims_dict).values
-        if np.isfinite(values[counter]):
-            counter += 1
+    len_data_dims = len(dataarray_dims)
+
+    dims_dict = {
+        dataarray_dims[ii]: np.array(
+            [randint(0, len(dataarray[dataarray_dims[ii]])) for nn in range(n)],
+            dtype=int,
+        )
+        for ii in range(len_data_dims)
+    }
+    values = dataarray.isel(dims_dict).values
+
     return values
 
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -41,7 +41,7 @@ should support the load of any datacube.
    examples/import_gebco_netCDF
    examples/simple_animation
    examples/import_ECMWF_netCDF
-   examples/node_tree_editor
+   .. examples/node_tree_editor
    examples/import_ECMWF_grib
    examples/displacement_animation
    examples/multiple_field_animations

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 numpy
+bottleneck==1.2.1
 cython
 zarr
 ecmwflibs

--- a/tests/blendernc_performance.test.py
+++ b/tests/blendernc_performance.test.py
@@ -1,0 +1,109 @@
+import os
+import sys
+import time
+import unittest
+import warnings
+
+import bpy
+import dask.array.core as darc
+import numpy as np
+
+warnings.simplefilter(action="ignore", category=darc.PerformanceWarning)
+
+
+def capture_render_log(func):
+    def wrapper(*args, **kwargs):
+        logfile = "blender_render.log"
+        open(logfile, "a").close()
+        old = os.dup(1)
+        sys.stdout.flush()
+        os.close(1)
+        os.open(logfile, os.O_WRONLY)
+        func(*args, **kwargs)
+        os.close(1)
+        os.dup(old)
+
+    return wrapper
+
+
+@capture_render_log
+def render_image(file, var, res):
+
+    bpy.context.scene.blendernc_datacube_vars = var
+
+
+class Test_format_import(unittest.TestCase):
+    def test_performance_ssh(self):
+        file = os.path.abspath("./dataset/ssh_1995-01.nc")
+        var = "adt"
+        res = 100
+        samples = 100
+        times = np.zeros(samples)
+        for n in range(samples):
+            bpy.ops.wm.read_homefile()
+            bpy.context.scene.blendernc_file = file
+            bpy.context.scene.blendernc_resolution = res
+            tic = time.time()
+            render_image(file, var, res)
+            toc = time.time()
+            times[n] = toc - tic
+
+        print("[", end="")
+        for tt in times:
+            print(str(tt) + ",", end="")
+        print("]", end="\n")
+        # Frames must be more than 2
+        self.assertGreater(1 / np.mean(times), 2)
+
+    def test_performance_t2m(self):
+        file = os.path.abspath("./dataset/ECMWF_data.grib")
+        var = "t2m"
+        res = 100
+        samples = 100
+        times = np.zeros(samples)
+        for n in range(samples):
+            bpy.ops.wm.read_homefile()
+            bpy.context.scene.blendernc_file = file
+            bpy.context.scene.blendernc_resolution = res
+            tic = time.time()
+            render_image(file, var, res)
+            toc = time.time()
+            times[n] = toc - tic
+
+        print("[", end="")
+        for tt in times:
+            print(str(tt) + ",", end="")
+        print("]", end="\n")
+        # Frames must be more than 5
+        self.assertGreater(1 / np.mean(times), 5)
+
+
+suite = unittest.defaultTestLoader.loadTestsFromTestCase(Test_format_import)
+test = unittest.TextTestRunner().run(suite)
+
+ret = not test.wasSuccessful()
+sys.exit(ret)
+
+
+# # To plot
+# data = times
+# fig, axs = plt.subplots(3,figsize=(4,4),dpi=200,sharex=True)
+# axs[0].plot(x,data,'--k',label='Old load ADT (0.25 deg res)',alpha=0.3)
+# axs[0].plot([x[0],x[-1]],[data[0],data[-1]],'--k')
+# axs[0].set_ylabel('Load time (s)')
+# axs[0].grid()
+
+# axs[1].plot(x,np.round(1/np.asarray(data),1),'--k',label='Old load ADT (0.25 deg res)',alpha=0.3)
+# axs[1].plot([x[0],x[-1]],[1/np.asarray(data)[0],1/np.asarray(data)[-1]],'--k')
+# axs[1].set_ylabel('FPS')
+# axs[1].grid()
+
+# axs[2].plot(x,np.asarray(data)/np.asarray(data),'--r',alpha=0.3)
+# mean = np.mean(np.asarray(data)/np.asarray(data))
+# axs[2].plot([x[0],x[0-1]],[mean,mean],'-r')
+# axs[2].set_xlabel('iter (n)')
+# axs[2].set_ylabel('Ratio (old/new)')
+# axs[2].grid()
+
+# plt.show()
+# plt.close()


### PR DESCRIPTION
Double speed when initially loading dataset. 

The figure below shows the improvements over 100 iterations using the old and new versions of the code. Solid lines correspond to the new code, while the dashed lines correspond to the old version. Two datasets were visualized; in black global 0.25-degree resolution and blue global 1-degree resolution. 

![6426f743-7046-4fd5-9a1a-3583dc57222f](https://user-images.githubusercontent.com/9144063/131498692-5cc9a120-7991-46f8-98c8-6969cfbfc399.png)

This PR also implements: 
- A performance test 
- and solves the issue with the simple UI reporting an error because, at that stage, the resolution node did not exist.
