### PR TITLE
Support blender 3.3

### DIFF
--- a/blendernc/messages.py
+++ b/blendernc/messages.py
@@ -7,8 +7,8 @@ import bpy
 # TODO Replace all messages with print_message.
 # Possibly shift to class when blendernc is initiated. and move to logging.
 class PrintMessage(object):
-    def __init__(self, text, title, icon):
-        self.message = text()
+    def __init__(self, text, title, icon, edit_text=""):
+        self.message = text(edit_text)
         self.title = title
         self.icon = icon
 
@@ -83,6 +83,13 @@ def same_min_max_value():
     text += "Please increase the resolution "
     text += "or define the max and min values of the dataset "
     text += "by using a Range node."
+    return text
+
+
+def no_package(edit_text):
+    text = text = "{0} is not installed, thus the functionality is limited.".format(
+        edit_text
+    )
     return text
 
 

--- a/blendernc/messages.py
+++ b/blendernc/messages.py
@@ -7,8 +7,11 @@ import bpy
 # TODO Replace all messages with print_message.
 # Possibly shift to class when blendernc is initiated. and move to logging.
 class PrintMessage(object):
-    def __init__(self, text, title, icon, edit_text=""):
-        self.message = text(edit_text)
+    def __init__(self, text, title, icon, edit_text=None):
+        if edit_text is None:
+            self.message = text()
+        else:
+            self.message = text(edit_text)
         self.title = title
         self.icon = icon
 

--- a/blendernc/nodes/cmaps/cmapsnode.py
+++ b/blendernc/nodes/cmaps/cmapsnode.py
@@ -226,7 +226,10 @@ class BLENDERNC_CMAPS_NT_node(bpy.types.ShaderNodeCustomGroup):
     # Copy
     def copy(self, node):
         create_colormap_nodetree(self)
-        self.colormaps = default_colorramp()
+        # TODO: There seems to be a bug when copying this node... the node
+        # loses its inputs and outputs
+        # self.outputs.remove(self.outputs[0])
+        self.colormaps = self.colormaps
         update_operator(self)
         print("Copying from node ", node)
 

--- a/blendernc/preferences.py
+++ b/blendernc/preferences.py
@@ -2,7 +2,7 @@
 import os
 
 import bpy
-import dask.distributed as ddist
+import pkg_resources
 from bpy.app.handlers import persistent
 
 from blendernc.messages import PrintMessage, client_exists, load_after_restart
@@ -10,6 +10,11 @@ from blendernc.python_functions import build_enum_prop_list
 
 # Import auto updater
 from . import addon_updater_ops
+
+installed = {pkg.key for pkg in pkg_resources.working_set}
+
+if "distributed" in installed:
+    import dask.distributed as ddist
 
 
 def get_addon_preference():
@@ -228,7 +233,10 @@ class BlenderNC_Preferences(bpy.types.AddonPreferences):
         row.prop(self, "blendernc_workspace_shading", expand=True)
         row = layout.row()
         row.label(text="Use dask Client:")
-        row.prop(self, "blendernc_use_dask", expand=True)
+        if "distributed" in installed:
+            row.prop(self, "blendernc_use_dask", expand=True)
+        else:
+            row.label(text="dask.distributed is not installed.", icon="ERROR")
         row = layout.row()
         row.label(text="Auto-reload datasets:")
         row.prop(self, "blendernc_autoreload_datasets", expand=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ findlibs==0.0.2; python_version >= "3.6"
 fonttools==4.29.1; python_version >= "3.7"
 fsspec==2022.2.0; python_version >= "3.7"
 idna==3.3; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6"
+importlib-metadata<5.0
 kiwisolver==1.3.2; python_version >= "3.7"
 locket==0.2.1; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.7"
 matplotlib==3.5.1; python_version >= "3.7"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,48 +1,46 @@
-appdirs==1.4.4
-asciitree==0.3.3
-attrs==21.2.0
-certifi==2021.10.8
-cffi==1.15.0
-cftime==1.5.1.1
-charset-normalizer==2.0.7
-click==7.1.2
-cloudpickle==2.0.0
+appdirs==1.4.4; python_version >= "3.6"
+asciitree==0.3.3; python_version >= "3.7" and python_version < "4"
+attrs==21.4.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
+certifi==2021.10.8; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6"
+cffi==1.15.0; python_version >= "3.6"
+cfgrib==0.9.10.0; python_version >= "3.6"
+cftime==1.5.2
+charset-normalizer==2.0.12; python_full_version >= "3.6.0" and python_version >= "3.6"
+cloudpickle==2.0.0; python_version >= "3.7"
 cmocean==2.0
-colorcet==3.0.0
-cycler==0.11.0
-dask[distributed]==2021.11.1
-eccodes==1.3.3
-ecmwflibs==0.4.15
-cfgrib==0.9.9.1
-fasteners==0.16.3
-findlibs==0.0.2
-fonttools==4.28.1
-fsspec==2021.11.0
-idna==3.3
-kiwisolver==1.3.2
-locket==0.2.1
-matplotlib==3.5.0
+colorcet==3.0.0; python_version >= "2.7"
+cycler==0.11.0; python_version >= "3.7"
+dask==2021.12.0; python_version >= "3.7"
+distributed==1.9.2; python_version <= "3.9"
+eccodes==1.4.0; python_version >= "3.6"
+ecmwflibs>=0.4.14
+fasteners==0.17.3; python_version >= "3.7" and python_version < "4"
+findlibs==0.0.2; python_version >= "3.6"
+fonttools==4.29.1; python_version >= "3.7"
+fsspec==2022.2.0; python_version >= "3.7"
+idna==3.3; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6"
+kiwisolver==1.3.2; python_version >= "3.7"
+locket==0.2.1; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.7"
+matplotlib==3.5.1; python_version >= "3.7"
 netcdf4==1.5.8
-numcodecs==0.9.1
-numpy==1.21.4
-packaging==21.2
-pandas==1.1.5
-partd==1.2.0
-pillow==9.0.0
-pooch==1.5.2
-psutil==5.8.0
-pycparser==2.21
-pyparsing==2.4.7
-python-dateutil==2.8.2
-pytz==2021.3
-pyyaml==6.0
-requests==2.26.0
-scipy==1.7.2
-setuptools-scm==6.3.2
-six==1.16.0
-toml==0.10.2
-tomli==1.2.2
-toolz==0.11.2
-urllib3==1.26.7
-xarray[complete]==0.19.0
-zarr==2.10.2
+numpy==1.21.5; python_version >= "3.7" and python_version < "3.11"
+packaging==21.3; python_version >= "3.7"
+param==1.12.0; python_version >= "2.7"
+partd==1.2.0; python_version >= "3.7"
+pillow==9.0.1; python_version >= "3.7"
+pooch==1.6.0; python_version >= "3.6"
+pycparser==2.21; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6"
+pyct==0.4.8; python_version >= "2.7"
+pyparsing==3.0.7; python_version >= "3.7"
+python-dateutil==2.8.2; python_full_version >= "3.6.1" and python_version >= "3.7"
+pytz==2021.3; python_full_version >= "3.6.1" and python_version >= "3.7"
+pyyaml==6.0; python_version >= "3.7"
+requests==2.27.1; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.6.0")
+scipy==1.7.3; python_version >= "3.7" and python_version < "3.11"
+setuptools-scm==6.4.2; python_version >= "3.7"
+six==1.16.0; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.7"
+toml==0.10.2; (python_version >= "2.6" and python_full_version < "3.0.0") or (python_full_version >= "3.3.0")
+tomli==2.0.1; python_version >= "3.7"
+toolz==0.11.2; python_version >= "3.5"
+urllib3==1.26.8; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version < "4" and python_version >= "3.6"
+xarray>=0.19.0; python_version >= "3.7"

--- a/tests/build-test.sh
+++ b/tests/build-test.sh
@@ -13,6 +13,7 @@ $BLENDERPY -m pip install -r requirements.txt --progress-bar off
 # TODO: Documentation on how to fully take advantages of both of these
 #       libraries.
 $BLENDERPY -m pip install distributed zarr
+$BLENDERPY -m pip install dask[complete] xarray[complete]
 
 $BLENDERPY -m pip install coverage --progress-bar off
 

--- a/tests/build-test.sh
+++ b/tests/build-test.sh
@@ -8,6 +8,12 @@ $BLENDERPY -m ensurepip --default-pip
 
 $BLENDERPY -m pip install -r requirements.txt --progress-bar off
 
+# The following line works since the docker container has the "Python.h" file
+# required by dependencies of distributed and zarr.
+# TODO: Documentation on how to fully take advantages of both of these
+#       libraries.
+$BLENDERPY -m pip install distributed zarr
+
 $BLENDERPY -m pip install coverage --progress-bar off
 
 $BLENDERPY -m pip install requests --progress-bar off


### PR DESCRIPTION
Changes in requirements.txt to support blender 3.3, the changes required to remove distributed and zarr since their compilations require the python-dev libs not included in the compiled version ofBlender